### PR TITLE
Added synchronous download of device test results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,14 @@
   
   <dependencies>
     <dependency>
-      <groupId>com.appthwack</groupId>
-      <artifactId>appthwack</artifactId>
-      <version>1.2</version>
+        <groupId>com.appthwack</groupId>
+        <artifactId>appthwack</artifactId>
+        <version>1.2</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.3.1</version>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
Ideally, I guess you would want this functionality to be subsumed into appthwack-java but it looks like AppThwackRun#downloadResults() isn't implemented yet: I have tried to keep all the download code in one single method (getTestResults), so that it can be refactored out at some future date.  At this stage, I haven't changed any of the UI for the plugin, nor made the results download optional, but that would be easy to do.  Device test results are stored in the workspace in a folder named "device-results-&lt;run id&gt;", with the individual devices as sub-folders as per the downloaded zip file.  I also tweaked a few of the javadoc parameter names to get rid of some errors where it looked like the names had changed from an earlier version.
